### PR TITLE
Add iOS open in browser bridge

### DIFF
--- a/Mixin/UserInterface/Controllers/Common/Web/MixinWebViewController.swift
+++ b/Mixin/UserInterface/Controllers/Common/Web/MixinWebViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WebKit
+import SafariServices
 import Alamofire
 import MixinServices
 
@@ -385,6 +386,8 @@ extension MixinWebViewController: WebViewMessageHandler.Delegate {
             web3Worker.handleRequest(json: json)
         case .signBotSignature(let callback):
             webView.evaluateJavaScript(callback)
+        case .openInBrowser(let url):
+            present(SFSafariViewController(url: url), animated: true)
         }
     }
     

--- a/Mixin/UserInterface/Controllers/Common/Web/WebViewMessageHandler.swift
+++ b/Mixin/UserInterface/Controllers/Common/Web/WebViewMessageHandler.swift
@@ -18,6 +18,7 @@ final class WebViewMessageHandler: NSObject, WKScriptMessageHandler {
         case getAssets = "getAssets"
         case web3Bridge = "_mw_"
         case signBotSignature = "signBotSignature"
+        case openInBrowser = "openInBrowser"
     }
     
     enum Message {
@@ -28,6 +29,7 @@ final class WebViewMessageHandler: NSObject, WKScriptMessageHandler {
         case getAssets(assetIDs: [String], callback: String)
         case web3Bridge([String: Any])
         case signBotSignature(callback: String)
+        case openInBrowser(URL)
     }
     
     private enum AppSigningError: Error {
@@ -157,7 +159,35 @@ final class WebViewMessageHandler: NSObject, WKScriptMessageHandler {
                     }
                 }
             }
+        case .openInBrowser:
+            guard let urlString = message.body as? String,
+                  let url = Self.openInBrowserURL(from: urlString)
+            else {
+                return
+            }
+            delegate?.webViewMessageHander(self, didReceiveMessage: .openInBrowser(url))
         }
     }
-    
+
+}
+
+extension WebViewMessageHandler {
+
+    static func openInBrowserURL(from value: String) -> URL? {
+        let urlString = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !urlString.isEmpty,
+              !["undefined", "null"].contains(urlString.lowercased())
+        else {
+            return nil
+        }
+
+        guard let url = URL(string: urlString),
+              ["http", "https"].contains(url.scheme?.lowercased() ?? ""),
+              url.host?.isEmpty == false
+        else {
+            return nil
+        }
+        return url
+    }
+
 }

--- a/Mixin/UserInterface/Controllers/Wallet/Buy/BuyTokenWebViewController.swift
+++ b/Mixin/UserInterface/Controllers/Wallet/Buy/BuyTokenWebViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WebKit
+import SafariServices
 import MixinServices
 
 final class BuyTokenWebViewController: PopupTitledWebViewController {
@@ -160,6 +161,8 @@ extension BuyTokenWebViewController: WebViewMessageHandler.Delegate {
             break
         case .signBotSignature(let callback):
             webView.evaluateJavaScript(callback)
+        case .openInBrowser(let url):
+            present(SFSafariViewController(url: url), animated: true)
         }
     }
     


### PR DESCRIPTION
## Summary
- Add `openInBrowser` to the iOS web bridge and present accepted URLs with `SFSafariViewController`.
- Wire the bridge through the common web controller and buy-token web controller.
- Require JS callers to provide an explicit HTTP or HTTPS URL, rejecting bare domains, non-web schemes, and malformed HTTP(S) URLs without a host.

## Validation
- Checked that this PR diff is limited to the native bridge files.
- Ran the split test branch full iOS test entrypoint locally; 8 tests passed.

Follow-up test PR: #2079.
Related Android PR: https://github.com/MixinNetwork/android-app/pull/6422