### PR TITLE
Prevent captcha retry loop

### DIFF
--- a/Mixin/UserInterface/Controllers/Login/LoginVerificationCodeViewController.swift
+++ b/Mixin/UserInterface/Controllers/Login/LoginVerificationCodeViewController.swift
@@ -53,13 +53,18 @@ class LoginVerificationCodeViewController: VerificationCodeViewController, Login
                 self.resendButton.beginCountDown(self.resendInterval)
             case let .failure(.response(error)) where .requiresCaptcha ~= error:
                 Logger.login.info(category: "LoginVerificationCode", message: "captcha")
-                self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
-                    switch result {
-                    case .success(let token):
-                        self?.requestVerificationCode(captchaToken: token)
-                    default:
-                        self?.resendButton.isBusy = false
+                if token == nil {
+                    self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
+                        switch result {
+                        case .success(let token):
+                            self?.requestVerificationCode(captchaToken: token)
+                        default:
+                            self?.resendButton.isBusy = false
+                        }
                     }
+                } else {
+                    self.alert(R.string.localizable.error_captcha_is_invalid())
+                    self.resendButton.isBusy = false
                 }
             case let .failure(error):
                 Logger.login.error(category: "LoginVerificationCode", message: "Failed: \(error)")

--- a/Mixin/UserInterface/Controllers/Login/LoginWithMnemonicViewController.swift
+++ b/Mixin/UserInterface/Controllers/Login/LoginWithMnemonicViewController.swift
@@ -226,13 +226,17 @@ extension LoginWithMnemonicViewController {
                 }
             case let .failure(.response(error)) where .requiresCaptcha ~= error:
                 Logger.login.info(category: "MnemonicLogin", message: "Captcha")
-                self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
-                    switch result {
-                    case .success(let token):
-                        self?.verifySession(mnemonics: mnemonics, captchaToken: token)
-                    case .cancel, .timedOut:
-                        self?.navigationController?.popViewController(animated: true)
+                if captchaToken == nil {
+                    self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
+                        switch result {
+                        case .success(let token):
+                            self?.verifySession(mnemonics: mnemonics, captchaToken: token)
+                        case .cancel, .timedOut:
+                            self?.navigationController?.popViewController(animated: true)
+                        }
                     }
+                } else {
+                    self.showError(R.string.localizable.error_captcha_is_invalid())
                 }
             case .failure(let error):
                 Logger.login.error(category: "MnemonicLogin", message: "\(error)")

--- a/Mixin/UserInterface/Controllers/Login/SignInWithMobileNumberViewController.swift
+++ b/Mixin/UserInterface/Controllers/Login/SignInWithMobileNumberViewController.swift
@@ -131,13 +131,18 @@ extension SignInWithMobileNumberViewController {
                 self.navigationController?.pushViewController(verify, animated: true)
                 self.updateViews(isBusy: false)
             case let .failure(.response(error)) where .requiresCaptcha ~= error:
-                self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
-                    switch result {
-                    case .success(let token):
-                        self?.requestVerificationCode(captchaToken: token)
-                    default:
-                        self?.updateViews(isBusy: false)
+                if token == nil {
+                    self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
+                        switch result {
+                        case .success(let token):
+                            self?.requestVerificationCode(captchaToken: token)
+                        default:
+                            self?.updateViews(isBusy: false)
+                        }
                     }
+                } else {
+                    self.alert(R.string.localizable.error_captcha_is_invalid())
+                    self.updateViews(isBusy: false)
                 }
             case let .failure(error):
                 Logger.login.error(category: "SignUpWithMobileNumber", message: "Failed: \(error)")

--- a/Mixin/UserInterface/Controllers/Setting/DeleteAccountSettingViewController.swift
+++ b/Mixin/UserInterface/Controllers/Setting/DeleteAccountSettingViewController.swift
@@ -173,13 +173,17 @@ extension DeleteAccountSettingViewController {
                 let vc = DeleteAccountVerifyCodeViewController(context: context)
                 self.navigationController?.pushViewController(vc, animated: true)
             case let .failure(.response(error)) where .requiresCaptcha ~= error:
-                self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
-                    switch result {
-                    case .success(let token):
-                        self?.requestVerificationCode(for: phone, captchaToken: token, displayingHUD: hud)
-                    case .cancel, .timedOut:
-                        hud.hide()
+                if token == nil {
+                    self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
+                        switch result {
+                        case .success(let token):
+                            self?.requestVerificationCode(for: phone, captchaToken: token, displayingHUD: hud)
+                        case .cancel, .timedOut:
+                            hud.hide()
+                        }
                     }
+                } else {
+                    hud.set(style: .error, text: R.string.localizable.error_captcha_is_invalid())
                 }
             case let .failure(error):
                 hud.hide()
@@ -189,4 +193,3 @@ extension DeleteAccountSettingViewController {
     }
     
 }
-

--- a/Mixin/UserInterface/Controllers/Setting/DeleteAccountVerifyCodeViewController.swift
+++ b/Mixin/UserInterface/Controllers/Setting/DeleteAccountVerifyCodeViewController.swift
@@ -48,13 +48,18 @@ final class DeleteAccountVerifyCodeViewController: VerificationCodeViewControlle
                 self.resendButton.isBusy = false
                 self.resendButton.beginCountDown(self.resendInterval)
             case let .failure(.response(error)) where .requiresCaptcha ~= error:
-                self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
-                    switch result {
-                    case .success(let token):
-                        self?.requestVerificationCode(captchaToken: token)
-                    default:
-                        self?.resendButton.isBusy = false
+                if token == nil {
+                    self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
+                        switch result {
+                        case .success(let token):
+                            self?.requestVerificationCode(captchaToken: token)
+                        default:
+                            self?.resendButton.isBusy = false
+                        }
                     }
+                } else {
+                    self.alert(R.string.localizable.error_captcha_is_invalid())
+                    self.resendButton.isBusy = false
                 }
             case .failure(let error):
                 self.alert(error.localizedDescription)

--- a/Mixin/UserInterface/Controllers/Setting/Mobile Number/VerifyMobileNumberInputNumberViewController.swift
+++ b/Mixin/UserInterface/Controllers/Setting/Mobile Number/VerifyMobileNumberInputNumberViewController.swift
@@ -128,13 +128,18 @@ final class VerifyMobileNumberInputNumberViewController: MobileNumberViewControl
                 self.navigationController?.pushViewController(oneTimeCode, animated: true)
                 self.continueButton.isBusy = false
             case let .failure(.response(error)) where .requiresCaptcha ~= error:
-                self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
-                    switch result {
-                    case .success(let token):
-                        self?.requestVerificationCode(base64Salt: base64Salt, captchaToken: token)
-                    default:
-                        self?.continueButton.isBusy = false
+                if token == nil {
+                    self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
+                        switch result {
+                        case .success(let token):
+                            self?.requestVerificationCode(base64Salt: base64Salt, captchaToken: token)
+                        default:
+                            self?.continueButton.isBusy = false
+                        }
                     }
+                } else {
+                    self.alert(R.string.localizable.error_captcha_is_invalid())
+                    self.continueButton.isBusy = false
                 }
             case let .failure(error):
                 self.alert(error.localizedDescription)

--- a/Mixin/UserInterface/Controllers/Setting/Mobile Number/VerifyMobileNumberOneTimeCodeViewController.swift
+++ b/Mixin/UserInterface/Controllers/Setting/Mobile Number/VerifyMobileNumberOneTimeCodeViewController.swift
@@ -120,13 +120,18 @@ class VerifyMobileNumberOneTimeCodeViewController: VerificationCodeViewControlle
                 self.resendButton.isBusy = false
                 self.resendButton.beginCountDown(self.resendInterval)
             case let .failure(.response(error)) where .requiresCaptcha ~= error:
-                self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
-                    switch result {
-                    case .success(let token):
-                        self?.requestVerificationCode(captchaToken: token)
-                    default:
-                        self?.resendButton.isBusy = false
+                if token == nil {
+                    self.captcha.validate(errorDescription: error.description) { [weak self] (result) in
+                        switch result {
+                        case .success(let token):
+                            self?.requestVerificationCode(captchaToken: token)
+                        default:
+                            self?.resendButton.isBusy = false
+                        }
                     }
+                } else {
+                    self.alert(R.string.localizable.error_captcha_is_invalid())
+                    self.resendButton.isBusy = false
                 }
             case let.failure(error):
                 self.alert(error.localizedDescription)


### PR DESCRIPTION
## Summary
- Stop automatically reopening captcha when a captcha-token retry still returns `requiresCaptcha`.
- Restore loading state and surface the existing invalid captcha error across login, resend, mnemonic, delete-account, and mobile-number verification flows.

## Validation
- Checked diff formatting.
- Verified all `requiresCaptcha` handlers are covered by the retry guard.
- Verified the latest commit has a valid SSH git signature locally.
- Attempted a simulator Debug build, but the local machine ran out of disk space while writing build artifacts before the build could complete.